### PR TITLE
build: update dist package.json to not use esm

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ export default {
   collectCoverage: true,
   collectCoverageFrom: ['**/src/**/*.js', '!**/node_modules/**'],
   coverageReporters: ['json', 'lcov', 'text', 'clover', 'text-summary'],
+  modulePathIgnorePatterns: ['dist'],
   testMatch: [
     '**/__tests__/**/*.js',
     /**

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "prepack": "babel src --out-dir dist",
+    "postpack": "node --experimental-json-modules ./postpack.js",
     "lint": "eslint . src __tests__ --ext .js,.cjs",
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest"
   },

--- a/postpack.js
+++ b/postpack.js
@@ -1,0 +1,10 @@
+import fs from 'fs'
+
+import pkg from './package.json'
+
+/**
+ * Remove "type": "module" until webpack supports ES modules better
+ */
+delete pkg.type
+
+fs.writeFileSync('./dist/package.json', JSON.stringify(pkg, null, 2))

--- a/postpack.js
+++ b/postpack.js
@@ -7,4 +7,6 @@ import pkg from './package.json'
  */
 delete pkg.type
 
+pkg.main = 'index.js'
+
 fs.writeFileSync('./dist/package.json', JSON.stringify(pkg, null, 2))


### PR DESCRIPTION
Webpack does not yet fully support ESM, in particular with regards to loaders: https://github.com/webpack/loader-runner/issues/61